### PR TITLE
Dev mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ netbox-kea-dhcp --netbox-url http://netbox-host \
     --kea-url http://kea-api-host --sync-now --listen -v
 ```
 
+The default mapping between netbox and Kea is:
+
+- prefixes are exported to subnets.
+- IP ranges are exported to pools.
+- IP Addresses are exported to reservations. Hardware address is mapped with IP
+  address custom field `dhcp_reservation_hw_address` if it exists and is non
+  null, otherwise it is mapped with the MAC address of the assigned object.
+
 At least one Netbox webhook needs to be configured for event listening. It has
 to notify all actions on DHCP-relevant objects:
 

--- a/examples/netbox-kea-dhcp.example.toml
+++ b/examples/netbox-kea-dhcp.example.toml
@@ -37,14 +37,15 @@ kea_url = "http://10.94.135.209:8000/"
 #
 # If the DHCP attribute have a dot and the part before the dot is "option-data"
 # the part after the dot will be added to option-data list as a dictionary
-# with two keys: "name"={part after the dot} and "value"={value from netbox}.
+# with two keys: "name"={part after the dot} and "data"={value from netbox}.
 # If the part before the dot is not a known list as option-data, the part after
 # will be a nested dictionary.
-# Each netbox fields may contain several dots which act as a seperator between
-# objects or dictionary keys.
-# A Netbox map may be a list of netbox fields. In this case, the first non-empty
-# field will be used as the DHCP value.
-# In respect to TOML syntax, attribute with dots in name need to be double-quoted.
+# Each netbox fields may contains several dots which are seperators between
+# nested objects or dictionary keys.
+# A Netbox map may be a list of netbox fields. In this case, the first
+# non-empty field will be used as the DHCP value.
+# In respect to TOML syntax, attribute with dots in name need to be
+# double-quoted.
 
 # Default subnet<->prefix map:
 #[subnet_prefix_map]
@@ -63,6 +64,7 @@ kea_url = "http://10.94.135.209:8000/"
 
 # Default IP reservation<->IP address map
 #[reservation_ipaddr_map]
+# "hw-address" and "hostname" DHCP settings are required
 ## Get MAC address from custom field, fallback to assigned interface MAC address
 #hw-address = [ "custom_fields.dhcp_resa_hw_address",
 #               "assigned_object.mac_address" ]
@@ -72,7 +74,7 @@ kea_url = "http://10.94.135.209:8000/"
 
 
 #
-# Filters: params injected into netbox API queries to restrict selected objects
+# Filters: params injected into netbox API queries to restrict object selection
 #
 # See API documentation on http://netbox-host/api/docs/.
 # IMPORTANT: non existent params are silently ignored!!
@@ -81,7 +83,7 @@ kea_url = "http://10.94.135.209:8000/"
 #[prefix_filter]
 #cf_dhcp_enabled = true
 
-# Example: filter out non-active prefixes
+# Example of a filte that includes only active prefixes
 [prefix_filter]
 status = "active"
 cf_dhcp_enabled = true

--- a/examples/netbox-kea-dhcp.example.toml
+++ b/examples/netbox-kea-dhcp.example.toml
@@ -31,22 +31,43 @@ kea_url = "http://10.94.135.209:8000/"
 # When set to false (default), a datetime and level name prefixes is used
 #syslog_level_prefix = true
 
+
 #
-# Netbox-DHCP maps: mapping from netbox custom fields to Kea DHCP attributes
+# Netbox-DHCP maps: mapping between Kea DHCP settings and netbox fields
 #
-# Default prefixes’map:
-#[prefix_dhcp_map]
-#dhcp_option_data_routers = "option-data.routers"
-#dhcp_option_data_domain_search = "option-data.domain-search"
-#dhcp_option_data_domain_name_servers = "option-data.domain-name-servers"
-#dhcp_next_server = "next-server"
-#dhcp_boot_file_name = "boot-file-name"
-[subnet_prefix_map]
-option-data.routers = 'custom_fields.dhcp_option_data_routers'
-option-data.domain-search = 'custom_fields.dhcp_option_data_domain_search'
-option-data.domain-name-servers = 'custom_fields.dhcp_option_data_domain_name_servers'
-next-server = 'custom_fields.dhcp_next_server'
-boot-file-name = 'custom_fields.dhcp_boot_file_name'
+# If the DHCP attribute have a dot and the part before the dot is "option-data"
+# the part after the dot will be added to option-data list as a dictionary
+# with two keys: "name"={part after the dot} and "value"={value from netbox}.
+# If the part before the dot is not a known list as option-data, the part after
+# will be a nested dictionary.
+# Each netbox fields may contain several dots which act as a seperator between
+# objects or dictionary keys.
+# A Netbox map may be a list of netbox fields. In this case, the first non-empty
+# field will be used as the DHCP value.
+# In respect to TOML syntax, attribute with dots in name need to be double-quoted.
+
+# Default subnet<->prefix map:
+#[subnet_prefix_map]
+#"option-data.routers" = "custom_fields.dhcp_option_data_routers"
+#"option-data.domain-search" = "custom_fields.dhcp_option_data_domain_search"
+#"option-data.domain-name-servers" = "custom_fields.dhcp_option_data_domain_name_servers"
+#next-server = "custom_fields.dhcp_next_server"
+#boot-file-name = "custom_fields.dhcp_boot_file_name"
+# Example of a nested DHCP dictionary
+#"user-context.netbox_tenant" = "tenant.name"
+
+# Default pool<->IP range map: no map
+#[pool_iprange_map]
+
+# Default IP reservation<->IP address map
+#[reservation_ipaddr_map]
+## Get MAC address from custom field, fallback to assigned interface MAC address
+#hw-address = [ "custom_fields.dhcp_resa_hw_address",
+#               "assigned_object.mac_address" ]
+# Get hostname from DNS name, fallback to device/vm name
+#hostname = [ "dns_name", "assigned_object.device.name",
+#             "assigned_object.virtual_machine.name"]
+
 
 #
 # Filters: params injected into netbox API queries to restrict selected objects
@@ -58,14 +79,14 @@ boot-file-name = 'custom_fields.dhcp_boot_file_name'
 #[prefix_filter]
 #cf_dhcp_enabled = true
 
-# Example: restrict prefixes
+# Example: filter out non-active prefixes
 [prefix_filter]
 status = "active"
 cf_dhcp_enabled = true
 
 # Default IP range filter:
 #[iprange_filter]
-# ATTENTION: "dhcp" is a custom status value, it needs to be created (in v3.4)
+## ATTENTION: "dhcp" is a custom status value, it needs to be created (in v3.4)
 #status = "dhcp"
 
 # Default IP address filter:

--- a/examples/netbox-kea-dhcp.example.toml
+++ b/examples/netbox-kea-dhcp.example.toml
@@ -41,6 +41,12 @@ kea_url = "http://10.94.135.209:8000/"
 #dhcp_option_data_domain_name_servers = "option-data.domain-name-servers"
 #dhcp_next_server = "next-server"
 #dhcp_boot_file_name = "boot-file-name"
+[subnet_prefix_map]
+option-data.routers = 'custom_fields.dhcp_option_data_routers'
+option-data.domain-search = 'custom_fields.dhcp_option_data_domain_search'
+option-data.domain-name-servers = 'custom_fields.dhcp_option_data_domain_name_servers'
+next-server = 'custom_fields.dhcp_next_server'
+boot-file-name = 'custom_fields.dhcp_boot_file_name'
 
 #
 # Filters: params injected into netbox API queries to restrict selected objects

--- a/examples/netbox-kea-dhcp.example.toml
+++ b/examples/netbox-kea-dhcp.example.toml
@@ -53,8 +53,10 @@ kea_url = "http://10.94.135.209:8000/"
 #"option-data.domain-name-servers" = "custom_fields.dhcp_option_data_domain_name_servers"
 #next-server = "custom_fields.dhcp_next_server"
 #boot-file-name = "custom_fields.dhcp_boot_file_name"
+#valid-lifetime = "custom_fields.dhcp_valid_lifetime"
+
 # Example of a nested DHCP dictionary
-#"user-context.netbox_tenant" = "tenant.name"
+#"user-context.tenant" = "tenant.name"
 
 # Default pool<->IP range map: no map
 #[pool_iprange_map]

--- a/examples/netbox-kea-dhcp.example.toml
+++ b/examples/netbox-kea-dhcp.example.toml
@@ -66,7 +66,7 @@ kea_url = "http://10.94.135.209:8000/"
 #[reservation_ipaddr_map]
 # "hw-address" and "hostname" DHCP settings are required
 ## Get MAC address from custom field, fallback to assigned interface MAC address
-#hw-address = [ "custom_fields.dhcp_resa_hw_address",
+#hw-address = [ "custom_fields.dhcp_reservation_hw_address",
 #               "assigned_object.mac_address" ]
 # Get hostname from DNS name, fallback to device/vm name
 #hostname = [ "dns_name", "assigned_object.device.name",

--- a/examples/netbox-kea-dhcp.example.toml
+++ b/examples/netbox-kea-dhcp.example.toml
@@ -47,12 +47,20 @@ kea_url = "http://10.94.135.209:8000/"
 #
 # See API documentation on http://netbox-host/api/docs/.
 # IMPORTANT: non existent params are silently ignored!!
+
+# Default prefix filter:
+#[prefix_filter]
+#cf_dhcp_enabled = true
+
+# Example: restrict prefixes
 [prefix_filter]
 status = "active"
 cf_dhcp_enabled = true
 
-[iprange_filter]
-status = "dhcp"    # "dhcp" value is a custom status as of netbox version 3.4
+# Default IP range filter:
+#[iprange_filter]
+# ATTENTION: "dhcp" is a custom status value, it needs to be created (in v3.4)
+#status = "dhcp"
 
 # Default IP address filter:
 #[ipaddress_filter]

--- a/src/netboxkea/config.py
+++ b/src/netboxkea/config.py
@@ -26,9 +26,10 @@ class Config:
     kea_url: str = None
     netbox_url: str = None
     netbox_token: str = None
-    prefix_filter: dict = field(default_factory=dict)
+    prefix_filter: dict = field(default_factory=lambda: {
+        'cf_dhcp_enabled': True})
     ipaddress_filter: dict = field(default_factory=lambda: {'status': 'dhcp'})
-    iprange_filter: dict = field(default_factory=dict)
+    iprange_filter: dict = field(default_factory=lambda: {'status': 'dhcp'})
     subnet_prefix_map: dict = field(default_factory=lambda: {
         'option-data.routers': 'custom_fields.dhcp_option_data_routers',
         'option-data.domain-search':

--- a/src/netboxkea/config.py
+++ b/src/netboxkea/config.py
@@ -42,7 +42,7 @@ class Config:
     pool_iprange_map: dict = field(default_factory=lambda: {})
     reservation_ipaddr_map: dict = field(default_factory=lambda: {
         # Get MAC address from custom field, fallback to assigned interface
-        'hw-address': ['custom_fields.dhcp_resa_hw_address',
+        'hw-address': ['custom_fields.dhcp_reservation_hw_address',
                        'assigned_object.mac_address'],
         # Get hostname from DNS name, fallback to device/vm name
         'hostname': ['dns_name', 'assigned_object.device.name',

--- a/src/netboxkea/config.py
+++ b/src/netboxkea/config.py
@@ -37,7 +37,8 @@ class Config:
         'option-data.domain-name-servers':
             'custom_fields.dhcp_option_data_domain_name_servers',
         'next-server': 'custom_fields.dhcp_next_server',
-        'boot-file-name': 'custom_fields.dhcp_boot_file_name'})
+        'boot-file-name': 'custom_fields.dhcp_boot_file_name',
+        'valid-lifetime': 'custom_fields.dhcp_valid_lifetime'})
     pool_iprange_map: dict = field(default_factory=lambda: {})
     reservation_ipaddr_map: dict = field(default_factory=lambda: {
         # Get MAC address from custom field, fallback to assigned interface

--- a/src/netboxkea/config.py
+++ b/src/netboxkea/config.py
@@ -102,4 +102,13 @@ def get_config():
                 'arguments nor in configuration file (if any)')
             sys.exit(1)
 
-    return Config(**settings)
+    conf = Config(**settings)
+
+    if not set(['hw-address', 'hostname']).issubset(
+            conf.reservation_ipaddr_map):
+        logging.fatal(
+            'Setting "reservation_ipaddr_map" must have a mapping for '
+            '"hw-address" and "hostname" DHCP parameters')
+        sys.exit(1)
+
+    return conf

--- a/src/netboxkea/config.py
+++ b/src/netboxkea/config.py
@@ -29,13 +29,23 @@ class Config:
     prefix_filter: dict = field(default_factory=dict)
     ipaddress_filter: dict = field(default_factory=lambda: {'status': 'dhcp'})
     iprange_filter: dict = field(default_factory=dict)
-    prefix_dhcp_map: dict = field(default_factory=lambda: {
-        'dhcp_option_data_routers': 'option-data.routers',
-        'dhcp_option_data_domain_search': 'option-data.domain-search',
-        'dhcp_option_data_domain_name_servers':
-            'option-data.domain-name-servers',
-        'dhcp_next_server': 'next-server',
-        'dhcp_boot_file_name': 'boot-file-name'})
+    subnet_prefix_map: dict = field(default_factory=lambda: {
+        'option-data.routers': 'custom_fields.dhcp_option_data_routers',
+        'option-data.domain-search':
+            'custom_fields.dhcp_option_data_domain_search',
+        'option-data.domain-name-servers':
+            'custom_fields.dhcp_option_data_domain_name_servers',
+        'next-server': 'custom_fields.dhcp_next_server',
+        'boot-file-name': 'custom_fields.dhcp_boot_file_name'})
+    pool_iprange_map: dict = field(default_factory=lambda: {})
+    reservation_ipaddr_map: dict = field(default_factory=lambda: {
+        # Get MAC address from custom field, fallback to assigned interface
+        'hw-address': ['custom_fields.dhcp_resa_hw_address',
+                       'assigned_object.mac_address'],
+        # Get hostname from DNS name, fallback to device/vm name
+        'hostname': ['dns_name', 'assigned_object.device.name',
+                     'assigned_object.virtual_machine.name']
+        })
 
 
 def get_config():

--- a/src/netboxkea/connector.py
+++ b/src/netboxkea/connector.py
@@ -4,45 +4,71 @@ from ipaddress import ip_interface
 from .kea.exceptions import KeaError, KeaClientError, SubnetNotFound
 
 
-def _map_dhcp_attrs(dhcp_map, netbox_fields):
-    """ Convert netbox fields to DHCP configuration dictionary """
+def _get_nested_attr(obj, attrs, sep='.'):
+    """ Apply getattr on a nested list of attributes seperated by separator """
 
-    dhcp_conf = {}
-    # For each custom field, get corresponding DHCP server attribute
-    for k, v in netbox_fields.items():
-        # Kea don’t like None value (TODO even if JSON converts to "null"?)
-        if v is None:
-            continue
-        try:
-            # DHCP server attribute represents dot-separated nested attrs
-            parts = dhcp_map[k].split('.')
-        except KeyError:
-            # logging.debug(f'no mapping for netbox DHCP attr {k}')
-            continue
-        # option-data are in a list of data/name dict
-        if parts[0] == 'option-data':
-            dhcp_conf.setdefault('option-data', []).append(
-                {'name': parts[1], 'data': v})
-        else:
-            # Convert attribute parts to dict, except for the last part
-            # which actually hold the value.
-            opt = dhcp_conf
-            last_index = len(parts) - 1
-            for i, part in enumerate(parts):
-                if i < last_index:
-                    if part not in opt:
-                        opt[part] = {}
-                    opt = opt[part]
-            opt[part] = v
-    return dhcp_conf
+    value = obj
+    for a in attrs.split(sep):
+        value = getattr(value, a)
+
+    if value != obj:
+        return value
+
+
+def _set_dhcp_attr(dhcp_item, key, value):
+    """
+    Set value to DHCP item dictionary. Key may be nested keys separated
+    by dots, in which case each key represents a nested dictionary
+    """
+
+    k1, _, k2 = key.partition('.')
+    if not k2:
+        dhcp_item[key] = value
+    elif k1 in ['option-data']:
+        # Some keys hold a list of data/name dicts
+        dhcp_item.setdefault(k1, []).append(
+            {'name': k2, 'data': value})
+    else:
+        dhcp_item.setdefault(k1, {})[k2] = value
+
+
+def _mk_dhcp_item(nb_obj, mapping):
+    """ Convert a netbox object to a DHCP dictionary item """
+
+    dhcp_item = {}
+    for dhcp_attr, nb_attr in mapping.items():
+        # Get value from netbox object
+        attrs = [nb_attr] if isinstance(nb_attr, str) else nb_attr
+        # Map value is expected to be list of attributes. The first
+        # existing and non-null attribute is the DHCP value
+        value = None
+        for a in attrs:
+            try:
+                value = _get_nested_attr(nb_obj, a)
+            except AttributeError:
+                continue
+            if value:
+                break
+
+        # Set value to DHCP setting
+        # Kea don’t like None value (TODO even if JSON converts it to "null"?)
+        if value is not None:
+            _set_dhcp_attr(dhcp_item, dhcp_attr, value)
+
+    return dhcp_item
 
 
 class Connector:
-    def __init__(self, nb, kea, check=False, prefix_dhcp_map={}):
+    """ Main class that connects Netbox objects to Kea DHCP config items """
+
+    def __init__(self, nb, kea, prefix_subnet_map, pool_iprange_map,
+                 reservation_ipaddr_map, check=False):
         self.nb = nb
         self.kea = kea
+        self.subnet_prefix_map = prefix_subnet_map
+        self.pool_iprange_map = pool_iprange_map
+        self.reservation_ipaddr_map = reservation_ipaddr_map
         self.check = check
-        self.prefix_dhcp_map = prefix_dhcp_map
 
     def sync_all(self):
         """ Replace current DHCP configuration by a new generated one """
@@ -125,19 +151,18 @@ class Connector:
             self.sync_ipaddress(i.id)
 
     def _prefix_to_subnet(self, pref, fullsync=False):
-        options = _map_dhcp_attrs(self.prefix_dhcp_map, pref.custom_fields)
+        subnet = _mk_dhcp_item(pref, self.subnet_prefix_map)
+        subnet['subnet'] = pref.prefix
         if not fullsync:
             try:
-                self.kea.set_subnet_options(
-                    prefix_id=pref.id, subnet=pref.prefix, options=options)
+                self.kea.update_subnet(pref.id, subnet)
             except SubnetNotFound:
                 # No subnet matching prefix_id/subnet_value. Create a new one
                 self.kea.del_subnet(pref.id, commit=False)
                 fullsync = True
 
         if fullsync:
-            self.kea.set_subnet(
-                prefix_id=pref.id, subnet=pref.prefix, options=options)
+            self.kea.set_subnet(pref.id, subnet)
             # Add host reservations
             for i in self.nb.ip_addresses(parent=pref.prefix):
                 try:
@@ -154,13 +179,13 @@ class Connector:
     def _iprange_to_pool(self, iprange, prefix=None):
         prefixes = [prefix] if prefix else self.nb.prefixes(
             contains=iprange.start_address)
+        pool = _mk_dhcp_item(iprange, self.pool_iprange_map)
+        start = str(ip_interface(iprange.start_address).ip)
+        end = str(ip_interface(iprange.end_address).ip)
+        pool['pool'] = f'{start}-{end}'
         for pref in prefixes:
             try:
-                start = str(ip_interface(iprange.start_address).ip)
-                end = str(ip_interface(iprange.end_address).ip)
-                self.kea.set_pool(
-                    prefix_id=pref.id, iprange_id=iprange.id, start=start,
-                    end=end)
+                self.kea.set_pool(pref.id, iprange.id, pool)
             except SubnetNotFound:
                 logging.warning(
                     f'subnet {pref.prefix} is missing, let’s sync it again')
@@ -169,19 +194,10 @@ class Connector:
     def _ipaddr_to_resa(self, ip, prefix=None):
         prefixes = [prefix] if prefix else self.nb.prefixes(
             contains=ip.address)
-        # Get hostname from DNS name, fallback to device name
-        if ip.dns_name:
-            hostname = ip.dns_name
-        else:
-            try:
-                hostname = ip.assigned_object.device.name
-            except AttributeError:
-                hostname = ip.assigned_object.virtual_machine.name
+        resa = _mk_dhcp_item(ip, self.reservation_ipaddr_map)
+        resa['ip-address'] = str(ip_interface(ip.address).ip)
         for pref in prefixes:
             try:
-                addr = str(ip_interface(ip.address).ip)
-                self.kea.set_reservation(
-                    prefix_id=pref.id, ipaddr_id=ip.id, ipaddr=addr,
-                    hw_addr=ip.assigned_object.mac_address, hostname=hostname)
+                self.kea.set_reservation(pref.id, ip.id, resa)
             except SubnetNotFound:
                 self._prefix_to_subnet(pref)

--- a/src/netboxkea/entry_point.py
+++ b/src/netboxkea/entry_point.py
@@ -20,7 +20,8 @@ def run():
         ipaddress_filter=conf.ipaddress_filter)
     kea = DHCP4App(conf.kea_url)
     conn = Connector(
-        nb, kea, check=conf.check_only, prefix_dhcp_map=conf.prefix_dhcp_map)
+        nb, kea, conf.subnet_prefix_map, conf.pool_iprange_map,
+        conf.reservation_ipaddr_map, check=conf.check_only)
 
     if not conf.full_sync_at_startup and not conf.listen:
         logging.warning('Neither full sync nor listen mode has been asked')

--- a/src/netboxkea/kea/app.py
+++ b/src/netboxkea/kea/app.py
@@ -206,7 +206,7 @@ class DHCP4App:
     def set_reservation(self, prefix_id, ipaddr_id, resa_item):
         """ Replace host reservation or append a new one """
 
-        for k in ('ip-address', 'hw-address', 'ip-address'):
+        for k in ('ip-address', 'hw-address'):
             if k not in resa_item:
                 raise TypeError(f'Missing mandatory reservation key: {k}')
 

--- a/src/netboxkea/kea/app.py
+++ b/src/netboxkea/kea/app.py
@@ -16,7 +16,7 @@ IP_ADDR = 'netbox_ip_address_id'
 
 
 def _autocommit(func):
-    """ Decoraton to autocommit changes after method execution """
+    """ Decorator to autocommit changes after method execution """
 
     def wrapper(self, *args, **kwargs):
         res = func(self, *args, **kwargs)

--- a/src/netboxkea/netbox.py
+++ b/src/netboxkea/netbox.py
@@ -35,17 +35,12 @@ class NetboxApp:
                 yield r
 
     def ip_address(self, id_):
-        i = self.nb.ipam.ip_addresses.get(
-            id=id_, assigned_to_interface=True, **self.ipaddress_filter)
-        if i and i.assigned_object.mac_address:
-            return i
+        return self.nb.ipam.ip_addresses.get(id=id_, **self.ipaddress_filter)
 
     def ip_addresses(self, **filters):
         if not filters:
             raise ValueError(
                 'Netboxapp.ip_addresses() requires at least one keyword arg')
         for i in self.nb.ipam.ip_addresses.filter(
-                assigned_to_interface=True, **self.ipaddress_filter,
-                **filters):
-            if i.assigned_object.mac_address:
-                yield i
+                **self.ipaddress_filter, **filters):
+            yield i

--- a/tests/fixtures/pynetbox/interfaces.py
+++ b/tests/fixtures/pynetbox/interfaces.py
@@ -61,7 +61,7 @@ _if_300.update({
     'device': devices.device_400,
     'display': 'pc-if0',
     'id': 300,
-    'mac_address': '11:22:33:44:55:66',
+    'mac_address': '11:11:11:11:11:11',
     'name': 'pc-if0',
     'url': 'http://netbox/api/dcim/interfaces/300/',
     })

--- a/tests/fixtures/pynetbox/ip_addresses.py
+++ b/tests/fixtures/pynetbox/ip_addresses.py
@@ -5,15 +5,49 @@ from pynetbox.models.ipam import IpAddresses
 
 from . import devices, interfaces, virtual_machines, vminterfaces
 
+ALL_IP = []
+
+
+def get(id_):
+    """ Emulate pynetbox.[…].Record.get()"""
+    for ip in ALL_IP:
+        if ip.id == id_:
+            return ip
+
+
+def filter_(interface_id=None, device_id=None, vminterface_id=None,
+            virtual_machine_id=None, **kwargs):
+    """ Emulate pynetbox.[…].Record.filter()"""
+
+    intf_id = vminterface_id if vminterface_id else interface_id
+    if intf_id:
+        return iter([ip for ip in ALL_IP if ip.assigned_object and
+                     ip.assigned_object.id == intf_id])
+    elif device_id:
+        return iter([ip for ip in ALL_IP if
+                     ip.assigned_object_type == 'dcim.interface'
+                     and ip.assigned_object.device.id == device_id])
+    elif virtual_machine_id:
+        return iter([ip for ip in ALL_IP if
+                     ip.assigned_object_type == 'virtualization.vminterface'
+                     and ip.assigned_object.virtual_machine.id ==
+                     virtual_machine_id])
+    else:
+        return iter(ALL_IP)
+
+
 api = Mock(base_url='http://netbox')
 
 _common = {
+    'assigned_object': None,
+    'assigned_object_id': None,
+    'assigned_object_type': None,
     'comments': '',
     'created': '2023-01-01T12:00:00.000000Z',
     'custom_fields': {},
     'description': '',
-    'has_details': False,
     'family': Record({'label': 'IPv4', 'value': 4}, api, None),
+    'has_details': False,
     'last_updated': '2023-01-01T12:00:00.000000Z',
     'nat_inside': None,
     'nat_outside': [],
@@ -35,23 +69,52 @@ _ip_200.update({
     'url': 'https://netbox/api/ipam/ip-addresses/200/'})
 
 ip_address_200 = IpAddresses(_ip_200, api, None)
+ALL_IP.append(ip_address_200)
 # Associate here IP address with device to avoid circular import failure
 devices.device_400.primary_ip = ip_address_200
 devices.device_400.primary_ip4 = ip_address_200
 
+_ip_201 = _common.copy()
+_ip_201.update({
+    'address': '192.168.0.2/24',
+    'custom_fields': {'dhcp_resa_hw_address': '22:22:22:22:22:22'},
+    'display': '192.168.0.2/24',
+    'dns_name': 'pc2.lan',
+    'id': 201,
+    'status': Record({'label': 'DHCP', 'value': 'dhcp'}, api, None),
+    'url': 'https://netbox/api/ipam/ip-addresses/201/'})
+ip_address_201 = IpAddresses(_ip_201, api, None)
+ALL_IP.append(ip_address_201)
+
+_ip_202 = _common.copy()
+_ip_202.update({
+    'address': '192.168.0.3/24',
+    'assigned_object': interfaces.interface_300,
+    'assigned_object_id': 300,
+    'assigned_object_type': 'dcim.interface',
+    'custom_fields': {'dhcp_resa_hw_address': '33:33:33:33:33:33'},
+    'display': '192.168.0.3/24',
+    'dns_name': 'pc3.lan',
+    'id': 202,
+    'status': Record({'label': 'DHCP', 'value': 'dhcp'}, api, None),
+    'url': 'https://netbox/api/ipam/ip-addresses/202/'})
+ip_address_202 = IpAddresses(_ip_202, api, None)
+ALL_IP.append(ip_address_202)
+
 _ip_250 = _common.copy()
 _ip_250.update({
-    'address': '192.168.0.51/24',
+    'address': '10.0.0.50/8',
     'assigned_object': vminterfaces.vminterface_350,
     'assigned_object_id': 350,
     'assigned_object_type': 'virtualization.vminterface',
-    'display': '192.168.0.51/24',
-    'dns_name': 'vm.lan',
+    'display': '10.0.0.50/8',
+    'dns_name': 'vm.lan10',
     'id': 250,
     'status': Record({'label': 'DHCP', 'value': 'dhcp'}, api, None),
     'url': 'https://netbox/api/ipam/ip-addresses/250/'})
 
 ip_address_250 = IpAddresses(_ip_250, api, None)
+ALL_IP.append(ip_address_250)
 # Associate here IP address with device to avoid circular import failure
 virtual_machines.virtual_machine_450.primary_ip = ip_address_250
 virtual_machines.virtual_machine_450.primary_ip4 = ip_address_250

--- a/tests/fixtures/pynetbox/prefixes.py
+++ b/tests/fixtures/pynetbox/prefixes.py
@@ -34,3 +34,13 @@ _pref_100.update({
     'prefix': '192.168.0.0/24'})
 
 prefix_100 = Prefixes(_pref_100, api, None)
+
+_pref_101 = _common.copy()
+_pref_101.update({
+    'custom_fields': {'dhcp_enable': True,
+                      'dhcp_option_data_domain_search': 'local, lan10',
+                      'dhcp_option_data_routers': '10.254.254.254'},
+    'display': '10.0.0.0/8',
+    'id': 101,
+    'prefix': '10.0.0.0/8'})
+prefix_101 = Prefixes(_pref_101, api, None)

--- a/tests/fixtures/pynetbox/vminterfaces.py
+++ b/tests/fixtures/pynetbox/vminterfaces.py
@@ -17,7 +17,7 @@ _common = {
     'has_details': True,
     'l2vpn_termination': None,
     'last_updated': '2023-03-28T08:15:56.256950Z',
-    'mac_address': '11:22:33:44:55:22',
+    'mac_address': '55:55:55:55:55:55',
     'mode': None,
     'mtu': None,
     'parent': None,

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -1,11 +1,34 @@
 import unittest
 from unittest.mock import Mock
 
-from netboxkea.connector import Connector
+from netboxkea.connector import _get_nested_attr, _set_dhcp_attr, Connector
 from netboxkea.kea.exceptions import SubnetNotFound
 from ..fixtures.pynetbox import ip_addresses as fixtip
 from ..fixtures.pynetbox import ip_ranges as fixtr
 from ..fixtures.pynetbox import prefixes as fixtp
+
+
+class TestConnectorFunctions(unittest.TestCase):
+
+    def test_get_nested_attr(self):
+        obj = Mock()
+        obj.assigned.device.name = 'pc.lan'
+        hostname = _get_nested_attr(obj, 'assigned.device.name')
+        self.assertEqual(hostname, 'pc.lan')
+
+    def test_set_dhcp_attr(self):
+        dhcp_item = {}
+        _set_dhcp_attr(dhcp_item, 'next-server', '10.0.0.1')
+        _set_dhcp_attr(dhcp_item, 'option-data.routers', '192.168.0.254')
+        _set_dhcp_attr(dhcp_item, 'option-data.domain-search', 'lan')
+        _set_dhcp_attr(dhcp_item, 'user-context.desc', 'Test')
+        _set_dhcp_attr(dhcp_item, 'user-context.note', 'Hello')
+        self.assertEqual(dhcp_item, {
+            'next-server': '10.0.0.1',
+            'option-data': [
+                {'name': 'routers', 'data': '192.168.0.254'},
+                {'name': 'domain-search', 'data': 'lan'}],
+            'user-context': {'desc': 'Test', 'note': 'Hello'}})
 
 
 class TestConnector(unittest.TestCase):
@@ -13,7 +36,12 @@ class TestConnector(unittest.TestCase):
     def setUp(self):
         self.nb = Mock()
         self.kea = Mock()
-        self.conn = Connector(self.nb, self.kea)
+        resa_ip_map = {
+            'hw-address': ['custom_fields.dhcp_resa_hw_address',
+                           'assigned_object.mac_address'],
+            'hostname': ['dns_name', 'assigned_object.device.name',
+                         'assigned_object.virtual_machine.name']}
+        self.conn = Connector(self.nb, self.kea, {}, {}, resa_ip_map)
         self.nb.prefix.return_value = fixtp.prefix_100
         self.nb.prefixes.return_value = iter([fixtp.prefix_100])
         self.nb.all_prefixes.return_value = iter([fixtp.prefix_100])
@@ -26,9 +54,9 @@ class TestConnector(unittest.TestCase):
         self.conn.sync_ipaddress(200)
         self.nb.ip_address.assert_called_once_with(200)
         self.nb.prefixes.assert_called_once_with(contains='192.168.0.1/24')
-        self.kea.set_reservation.assert_called_once_with(
-            prefix_id=100, ipaddr_id=200, ipaddr='192.168.0.1',
-            hw_addr='11:22:33:44:55:66', hostname='pc.lan')
+        self.kea.set_reservation.assert_called_once_with(100, 200, {
+                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
+                'hostname': 'pc.lan'})
 
     def test_sync_ip_address_del(self):
         self.nb.ip_address.return_value = None
@@ -38,22 +66,21 @@ class TestConnector(unittest.TestCase):
 
     def test_sync_prefix_options(self):
         self.conn.sync_prefix(100)
-        self.kea.set_subnet_options.assert_called_once_with(
-            prefix_id=100, subnet='192.168.0.0/24', options={})
+        self.kea.update_subnet.assert_called_once_with(100, {
+            'subnet': '192.168.0.0/24'})
 
     def test_sync_prefix_fullsync(self):
-        self.kea.set_subnet_options.side_effect = SubnetNotFound()
+        self.kea.update_subnet.side_effect = SubnetNotFound()
         self.conn.sync_prefix(100)
         self.nb.ip_addresses.assert_called_once_with(parent='192.168.0.0/24')
         self.nb.ip_ranges.assert_called_once_with(parent='192.168.0.0/24')
-        self.kea.set_subnet.assert_called_once_with(
-            prefix_id=100, subnet='192.168.0.0/24', options={})
-        self.kea.set_reservation.assert_called_once_with(
-            prefix_id=100, ipaddr_id=200, ipaddr='192.168.0.1',
-            hw_addr='11:22:33:44:55:66', hostname='pc.lan')
-        self.kea.set_pool.assert_called_once_with(
-            prefix_id=100, iprange_id=250, start='192.168.0.100',
-            end='192.168.0.199')
+        self.kea.set_subnet.assert_called_once_with(100, {
+            'subnet': '192.168.0.0/24'})
+        self.kea.set_reservation.assert_called_once_with(100, 200, {
+                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
+                'hostname': 'pc.lan'})
+        self.kea.set_pool.assert_called_once_with(100, 250, {
+                'pool': '192.168.0.100-192.168.0.199'})
 
     def test_sync_prefix_del(self):
         self.nb.prefix.return_value = None
@@ -62,9 +89,8 @@ class TestConnector(unittest.TestCase):
 
     def test_sync_ip_range(self):
         self.conn.sync_iprange(250)
-        self.kea.set_pool.assert_called_once_with(
-            prefix_id=100, iprange_id=250, start='192.168.0.100',
-            end='192.168.0.199')
+        self.kea.set_pool.assert_called_once_with(100, 250, {
+                'pool': '192.168.0.100-192.168.0.199'})
 
     def test_sync_ip_range_del(self):
         self.nb.ip_range.return_value = None
@@ -73,39 +99,40 @@ class TestConnector(unittest.TestCase):
 
     def test_sync_interface(self):
         self.conn.sync_interface(300)
-        self.kea.set_reservation.assert_called_once_with(
-            prefix_id=100, ipaddr_id=200, ipaddr='192.168.0.1',
-            hw_addr='11:22:33:44:55:66', hostname='pc.lan')
+        self.kea.set_reservation.assert_called_once_with(100, 200, {
+                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
+                'hostname': 'pc.lan'})
 
     def test_sync_device(self):
         self.conn.sync_device(400)
-        self.kea.set_reservation.assert_called_once_with(
-            prefix_id=100, ipaddr_id=200, ipaddr='192.168.0.1',
-            hw_addr='11:22:33:44:55:66', hostname='pc.lan')
+        self.kea.set_reservation.assert_called_once_with(100, 200, {
+                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
+                'hostname': 'pc.lan'})
 
     def test_sync_vminterface(self):
         self.nb.ip_address.return_value = fixtip.ip_address_250
         self.conn.sync_vminterface(350)
-        self.kea.set_reservation.assert_called_once_with(
-            prefix_id=100, ipaddr_id=250, ipaddr='192.168.0.51',
-            hw_addr='11:22:33:44:55:22', hostname='vm.lan')
+        self.kea.set_reservation.assert_called_once_with(100, 250, {
+                'ip-address': '192.168.0.51',
+                'hw-address': '11:22:33:44:55:22',
+                'hostname': 'vm.lan'})
 
     def test_sync_virtualmachine(self):
         self.nb.ip_address.return_value = fixtip.ip_address_250
         self.conn.sync_virtualmachine(400)
-        self.kea.set_reservation.assert_called_once_with(
-            prefix_id=100, ipaddr_id=250, ipaddr='192.168.0.51',
-            hw_addr='11:22:33:44:55:22', hostname='vm.lan')
+        self.kea.set_reservation.assert_called_once_with(100, 250, {
+                'ip-address': '192.168.0.51',
+                'hw-address': '11:22:33:44:55:22',
+                'hostname': 'vm.lan'})
 
     def test_sync_all(self):
         self.conn.sync_all()
-        self.kea.set_subnet.assert_called_once_with(
-            prefix_id=100, subnet='192.168.0.0/24', options={})
-        self.kea.set_reservation.assert_called_once_with(
-            prefix_id=100, ipaddr_id=200, ipaddr='192.168.0.1',
-            hw_addr='11:22:33:44:55:66', hostname='pc.lan')
-        self.kea.set_pool.assert_called_once_with(
-            prefix_id=100, iprange_id=250, start='192.168.0.100',
-            end='192.168.0.199')
+        self.kea.set_subnet.assert_called_once_with(100, {
+            'subnet': '192.168.0.0/24'})
+        self.kea.set_reservation.assert_called_once_with(100, 200, {
+                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
+                'hostname': 'pc.lan'})
+        self.kea.set_pool.assert_called_once_with(100, 250, {
+                'pool': '192.168.0.100-192.168.0.199'})
         self.kea.commit.assert_called()
         self.kea.push.assert_called()

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -1,7 +1,7 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
-from netboxkea.connector import _get_nested_attr, _set_dhcp_attr, Connector
+from netboxkea.connector import _get_nested, _set_dhcp_attr, Connector
 from netboxkea.kea.exceptions import SubnetNotFound
 from ..fixtures.pynetbox import ip_addresses as fixtip
 from ..fixtures.pynetbox import ip_ranges as fixtr
@@ -10,13 +10,12 @@ from ..fixtures.pynetbox import prefixes as fixtp
 
 class TestConnectorFunctions(unittest.TestCase):
 
-    def test_get_nested_attr(self):
-        obj = Mock()
-        obj.assigned.device.name = 'pc.lan'
-        hostname = _get_nested_attr(obj, 'assigned.device.name')
+    def test_01_get_nested_attr(self):
+        obj = {'assigned': {'device': {'name': 'pc.lan'}}}
+        hostname = _get_nested(obj, 'assigned.device.name')
         self.assertEqual(hostname, 'pc.lan')
 
-    def test_set_dhcp_attr(self):
+    def test_02_set_dhcp_attr(self):
         dhcp_item = {}
         _set_dhcp_attr(dhcp_item, 'next-server', '10.0.0.1')
         _set_dhcp_attr(dhcp_item, 'option-data.routers', '192.168.0.254')
@@ -36,103 +35,126 @@ class TestConnector(unittest.TestCase):
     def setUp(self):
         self.nb = Mock()
         self.kea = Mock()
+
+        # Set up connector
         resa_ip_map = {
             'hw-address': ['custom_fields.dhcp_resa_hw_address',
                            'assigned_object.mac_address'],
             'hostname': ['dns_name', 'assigned_object.device.name',
                          'assigned_object.virtual_machine.name']}
         self.conn = Connector(self.nb, self.kea, {}, {}, resa_ip_map)
+
+        # Set up netbox mock
         self.nb.prefix.return_value = fixtp.prefix_100
         self.nb.prefixes.return_value = iter([fixtp.prefix_100])
         self.nb.all_prefixes.return_value = iter([fixtp.prefix_100])
         self.nb.ip_range.return_value = fixtr.ip_range_250
         self.nb.ip_ranges.return_value = iter([fixtr.ip_range_250])
-        self.nb.ip_address.return_value = fixtip.ip_address_200
-        self.nb.ip_addresses.return_value = iter([fixtip.ip_address_200])
+        self.nb.ip_address.side_effect = fixtip.get
+        self.nb.ip_addresses.side_effect = fixtip.filter_
 
-    def test_sync_ip_address(self):
+        # Define kea calls
+        self.call_subnet100 = call(100, {'subnet': '192.168.0.0/24'})
+        self.call_subnet101 = call(101, {'subnet': '10.0.0.0/8'})
+        self.call_resa200 = call(100, 200, {
+            'ip-address': '192.168.0.1', 'hw-address': '11:11:11:11:11:11',
+            'hostname': 'pc.lan'})
+        self.call_resa201 = call(100, 201, {
+            'ip-address': '192.168.0.2', 'hw-address': '22:22:22:22:22:22',
+            'hostname': 'pc2.lan'})
+        self.call_resa202 = call(100, 202, {
+            'ip-address': '192.168.0.3', 'hw-address': '33:33:33:33:33:33',
+            'hostname': 'pc3.lan'})
+        self.call_resa250 = call(100, 250, {
+            'ip-address': '10.0.0.50', 'hw-address': '55:55:55:55:55:55',
+            'hostname': 'vm.lan10'})
+        self.call_pool250 = call(100, 250, {
+            'pool': '192.168.0.100-192.168.0.199'})
+
+    def test_01_sync_ip_address_with_assigned_interface(self):
         self.conn.sync_ipaddress(200)
         self.nb.ip_address.assert_called_once_with(200)
         self.nb.prefixes.assert_called_once_with(contains='192.168.0.1/24')
-        self.kea.set_reservation.assert_called_once_with(100, 200, {
-                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
-                'hostname': 'pc.lan'})
+        self.kea.set_reservation.assert_has_calls([self.call_resa200])
 
-    def test_sync_ip_address_del(self):
-        self.nb.ip_address.return_value = None
+    def test_02_sync_ip_address_with_custom_field(self):
+        self.conn.sync_ipaddress(201)
+        self.nb.ip_address.assert_called_once_with(201)
+        self.nb.prefixes.assert_called_once_with(contains='192.168.0.2/24')
+        self.kea.set_reservation.assert_has_calls([self.call_resa201])
+
+    def test_03_sync_ip_address_with_assigned_and_custom_field(self):
+        self.conn.sync_ipaddress(202)
+        self.nb.ip_address.assert_called_once_with(202)
+        self.nb.prefixes.assert_called_once_with(contains='192.168.0.3/24')
+        self.kea.set_reservation.assert_has_calls([self.call_resa202])
+
+    def test_05_sync_ip_address_vm(self):
+        self.conn.sync_ipaddress(250)
+        self.nb.ip_address.assert_called_once_with(250)
+        self.nb.prefixes.assert_called_once_with(contains='10.0.0.50/8')
+        self.kea.set_reservation.assert_has_calls([self.call_resa250])
+
+    def test_09_sync_ip_address_del(self):
         self.conn.sync_ipaddress(249)
         self.nb.ip_address.assert_called_once_with(249)
         self.kea.del_resa.assert_called_once_with(249)
 
-    def test_sync_prefix_options(self):
-        self.conn.sync_prefix(100)
-        self.kea.update_subnet.assert_called_once_with(100, {
-            'subnet': '192.168.0.0/24'})
+    def test_10_sync_interface(self):
+        self.conn.sync_interface(300)
+        self.nb.ip_addresses.assert_called_once_with(interface_id=300)
+        self.kea.set_reservation.assert_has_calls([self.call_resa200])
 
-    def test_sync_prefix_fullsync(self):
-        self.kea.update_subnet.side_effect = SubnetNotFound()
-        self.conn.sync_prefix(100)
-        self.nb.ip_addresses.assert_called_once_with(parent='192.168.0.0/24')
-        self.nb.ip_ranges.assert_called_once_with(parent='192.168.0.0/24')
-        self.kea.set_subnet.assert_called_once_with(100, {
-            'subnet': '192.168.0.0/24'})
-        self.kea.set_reservation.assert_called_once_with(100, 200, {
-                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
-                'hostname': 'pc.lan'})
-        self.kea.set_pool.assert_called_once_with(100, 250, {
-                'pool': '192.168.0.100-192.168.0.199'})
+    def test_11_sync_device(self):
+        self.conn.sync_device(400)
+        self.nb.ip_addresses.assert_called_once_with(device_id=400)
+        self.kea.set_reservation.assert_has_calls([self.call_resa200])
 
-    def test_sync_prefix_del(self):
-        self.nb.prefix.return_value = None
-        self.conn.sync_prefix(199)
-        self.kea.del_subnet.assert_called_once_with(199)
+    def test_15_sync_vminterface(self):
+        self.conn.sync_vminterface(350)
+        self.nb.ip_addresses.assert_called_once_with(vminterface_id=350)
+        self.kea.set_reservation.assert_has_calls([self.call_resa250])
 
-    def test_sync_ip_range(self):
+    def test_16_sync_virtualmachine(self):
+        self.conn.sync_virtualmachine(450)
+        self.nb.ip_addresses.assert_called_once_with(virtual_machine_id=450)
+        self.kea.set_reservation.assert_has_calls([self.call_resa250])
+
+    def test_20_sync_ip_range(self):
         self.conn.sync_iprange(250)
-        self.kea.set_pool.assert_called_once_with(100, 250, {
-                'pool': '192.168.0.100-192.168.0.199'})
+        self.kea.set_pool.assert_has_calls([self.call_pool250])
 
-    def test_sync_ip_range_del(self):
+    def test_21_sync_ip_range_del(self):
         self.nb.ip_range.return_value = None
         self.conn.sync_iprange(299)
         self.kea.del_pool.assert_called_once_with(299)
 
-    def test_sync_interface(self):
-        self.conn.sync_interface(300)
-        self.kea.set_reservation.assert_called_once_with(100, 200, {
-                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
-                'hostname': 'pc.lan'})
-
-    def test_sync_device(self):
-        self.conn.sync_device(400)
-        self.kea.set_reservation.assert_called_once_with(100, 200, {
-                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
-                'hostname': 'pc.lan'})
-
-    def test_sync_vminterface(self):
-        self.nb.ip_address.return_value = fixtip.ip_address_250
-        self.conn.sync_vminterface(350)
-        self.kea.set_reservation.assert_called_once_with(100, 250, {
-                'ip-address': '192.168.0.51',
-                'hw-address': '11:22:33:44:55:22',
-                'hostname': 'vm.lan'})
-
-    def test_sync_virtualmachine(self):
-        self.nb.ip_address.return_value = fixtip.ip_address_250
-        self.conn.sync_virtualmachine(400)
-        self.kea.set_reservation.assert_called_once_with(100, 250, {
-                'ip-address': '192.168.0.51',
-                'hw-address': '11:22:33:44:55:22',
-                'hostname': 'vm.lan'})
-
-    def test_sync_all(self):
-        self.conn.sync_all()
-        self.kea.set_subnet.assert_called_once_with(100, {
+    def test_30_sync_prefix_update(self):
+        self.conn.sync_prefix(100)
+        self.kea.update_subnet.assert_called_once_with(100, {
             'subnet': '192.168.0.0/24'})
-        self.kea.set_reservation.assert_called_once_with(100, 200, {
-                'ip-address': '192.168.0.1', 'hw-address': '11:22:33:44:55:66',
-                'hostname': 'pc.lan'})
-        self.kea.set_pool.assert_called_once_with(100, 250, {
-                'pool': '192.168.0.100-192.168.0.199'})
+
+    def test_31_sync_prefix_fullsync(self):
+        self.kea.update_subnet.side_effect = SubnetNotFound()
+        self.conn.sync_prefix(100)
+        self.nb.ip_addresses.assert_called_once_with(parent='192.168.0.0/24')
+        self.nb.ip_ranges.assert_called_once_with(parent='192.168.0.0/24')
+        self.kea.set_subnet.assert_has_calls([self.call_subnet100])
+        self.kea.set_reservation.assert_has_calls(
+            [self.call_resa200, self.call_resa201, self.call_resa202])
+        self.kea.set_pool.assert_has_calls([self.call_pool250])
+
+    def test_39_sync_prefix_del(self):
+        self.nb.prefix.return_value = None
+        self.conn.sync_prefix(199)
+        self.kea.del_subnet.assert_called_once_with(199)
+
+    def test_99_sync_all(self):
+        self.conn.sync_all()
+        self.kea.set_subnet.assert_has_calls([self.call_subnet100])
+        self.kea.set_reservation.assert_has_calls(
+            [self.call_resa200, self.call_resa201, self.call_resa202,
+             self.call_resa250])
+        self.kea.set_pool.assert_has_calls([self.call_pool250])
         self.kea.commit.assert_called()
         self.kea.push.assert_called()


### PR DESCRIPTION
All three DHCP items (subnets, pools and reservations) now use a generic code to map their parameters with netbox.
Mapping from netbox to kea may then be highly customized. A few attributes are still hard-coded as they should be obvious and fine (like Netbox IP address Address wich maps with Kea reservations ip-address)
