### PR TITLE
Add OCI image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+tests/
+examples/
+dist/
+venv/
+Dockerfile
+.gitignore

--- a/.github/workflows/publish-oci.yaml
+++ b/.github/workflows/publish-oci.yaml
@@ -1,0 +1,43 @@
+name: Publish OCI Images
+on:
+  push:
+    tags:
+    - '*'
+jobs:
+  publish:
+    name: "Build and publish OCI on GHCR"
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+    - name: Save the date
+      id: date
+      run: |
+        echo date=$(date --rfc-3339=seconds) >> $GITHUB_OUTPUT
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Login to GHCR
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Set up buildx
+      uses: docker/setup-buildx-action@v2
+    - name: Build and push containers
+      uses: docker/build-push-action@v4
+      with:
+        push: true
+        platforms: linux/amd64
+        tags: |
+          ghcr.io/${{ github.repository }}:${{  github.ref_name }}
+        labels: |
+          org.opencontainers.image.title=${{ github.event.repository.name }}
+          org.opencontainers.image.description=${{ github.event.repository.description }}
+          org.opencontainers.image.url=${{ github.event.repository.html_url }}
+          org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+          org.opencontainers.image.created=${{ steps.date.outputs.date }}
+          org.opencontainers.image.version=${{ steps.date.outputs.tag }}
+          org.opencontainers.image.revision=${{ github.sha }}
+          org.opencontainers.image.licenses=${{ github.event.repository.license.spdx_id }}
+      

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-alpine as base
+
+# Build
+FROM base as builder
+COPY . /source
+RUN python -m venv /venv
+RUN /venv/bin/pip install /source
+
+# Run
+FROM base as runner
+COPY --from=builder /venv /venv
+ENTRYPOINT ["/venv/bin/netbox-kea-dhcp"]


### PR DESCRIPTION
I'm using netbox-kea-dhcp (nice generic design, by the way, I like it!), and would like to use it from my Kubernetes cluster. One of the missing pieces to do so is a published OCI image, and this PR adds both the Dockerfile to build it, as well as the GitHub workflow to do so upon a pushed tag.

As there is no GH workflow in the project yet, I can imagine you'd want to revise it (ie, automatic tag/release, pypi publish, etc). Let me know if I can help with it.