### PR TITLE
Add health endpoint

### DIFF
--- a/src/netboxkea/listener.py
+++ b/src/netboxkea/listener.py
@@ -63,6 +63,12 @@ class WebhookListener:
 
             # Push change to DHCP server
             self.conn.push_to_dhcp()
+        
+        # very basic health check, basically proves bottle is already/still running
+        # enough for Kubernetes probes
+        @bottle.route('/health/')
+        def health():
+            return 'ok'
 
         # start server
         bottle.run(host=self.host, port=self.port)


### PR DESCRIPTION
Very simple route, that basically just returns status 200 and the text "ok". This is very useful for detecting if the webservice handling the events is up (for Kubernetes {startup,liveness,readiness} probes).