### PR TITLE
Add full sync function for method fullsync

### DIFF
--- a/src/netboxkea/connector.py
+++ b/src/netboxkea/connector.py
@@ -157,6 +157,11 @@ class Connector:
         for i in self.nb.ip_addresses(virtual_machine_id=id_):
             self.sync_ipaddress(i.id)
 
+    def sync_fullsync(self, id_):
+        # Additional check of id = 0 before syncing
+        if int(id_) == 0:
+            self.sync_all()
+
     def _prefix_to_subnet(self, pref, fullsync=False):
         subnet = _mk_dhcp_item(pref, self.subnet_prefix_map)
         subnet['subnet'] = pref.prefix


### PR DESCRIPTION
When my opnsense system is restarted, the Kea DHCP server reloads the local configuration, rather than saving the remotely sync configuration and reloading. 
To avoid having to manually restart the kea-dhcp service to force a full resync, I added a new sync_fullsync method which will execute on an api call for a json post body of the type
```
{
  "data":{
      "id":0},
  "model": "fullsync",
  "event": "Updates"
}
```

I feel this could be useful for others. 