### PR TITLE
Update netbox-kea-dhcp.example.toml

### DIFF
--- a/examples/netbox-kea-dhcp.example.toml
+++ b/examples/netbox-kea-dhcp.example.toml
@@ -67,7 +67,7 @@ kea_url = "http://10.94.135.209:8000/"
 # "hw-address" and "hostname" DHCP settings are required
 ## Get MAC address from custom field, fallback to assigned interface MAC address
 #hw-address = [ "custom_fields.dhcp_reservation_hw_address",
-#               "assigned_object.mac_address" ]
+#               "assigned_object.primary_mac_address.mac_address" ]
 # Get hostname from DNS name, fallback to device/vm name
 #hostname = [ "dns_name", "assigned_object.device.name",
 #             "assigned_object.virtual_machine.name"]


### PR DESCRIPTION
Pull the MAC address from `assigned_object.primary_mac_address.mac_address` to make this script compatible with recent Netbox versions